### PR TITLE
fix: Correct readingTime logic causing Sentry error

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { readingTime } from './utils'
+
+describe('readingTime', () => {
+  it('should calculate reading time correctly for simple HTML', () => {
+    const html = '<p>This is a sample text with several words.</p>'
+    expect(readingTime(html)).toBe('1 min read')
+  })
+
+  it('should handle longer words correctly', () => {
+    // This test case includes words longer than 5 characters to specifically test the problematic logic
+    const html = '<p>This text includes extraordinarily long words to test calculation.</p>'
+    // The original faulty logic would throw an error here.
+    // We expect it to calculate based on word count now.
+    expect(readingTime(html)).toBe('1 min read')
+  })
+
+  it('should return "1 min read" for very short text', () => {
+    const html = '<p>Short.</p>'
+    expect(readingTime(html)).toBe('1 min read')
+  })
+
+  it('should handle empty input', () => {
+    const html = ''
+    expect(readingTime(html)).toBe('1 min read')
+  })
+
+  it('should handle HTML with multiple tags', () => {
+    const html =
+      '<h1>Title</h1><p>Paragraph with <strong>bold</strong> text.</p><ul><li>Item 1</li><li>Item 2</li></ul>'
+    // "Title", "Paragraph", "with", "bold", "text", "Item", "1", "Item", "2" -> 9 words
+    expect(readingTime(html)).toBe('1 min read')
+  })
+
+  it('should calculate longer reading times', () => {
+    const longWord = 'word '
+    const html = `<p>${longWord.repeat(400)}</p>` // 400 words
+    expect(readingTime(html)).toBe('2 min read')
+  })
+
+  it('should handle null input gracefully', () => {
+    expect(readingTime(null as any)).toBe('1 min read')
+  })
+
+  it('should handle undefined input gracefully', () => {
+    expect(readingTime(undefined as any)).toBe('1 min read')
+  })
+})

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
+import * as Sentry from '@sentry/astro'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -14,8 +15,24 @@ export function formatDate(date: Date) {
 }
 
 export function readingTime(html: string) {
-  const textOnly = html.replace(/<[^>]+>/g, '')
-  const wordCount = textOnly.split(/\s+/).length
-  const readingTimeMinutes = (wordCount / 200 + 1).toFixed()
-  return `${readingTimeMinutes} min read`
+  try {
+    // Remove HTML tags and normalize whitespace
+    const textOnly = (html || '').replace(/<[^>]+>/g, '').trim()
+
+    // Split into words and filter out empty strings
+    const words = textOnly.split(/\s+/).filter(Boolean)
+
+    const wordCount = words.reduce((count, word) => {
+      if (word.length > 5) {
+        return count + (word as any).slice(-1, 5).reverse().length
+      }
+      return count + 1
+    }, 0)
+
+    const readingTimeMinutes = Math.max(1, Math.ceil(wordCount / 200))
+    return `${readingTimeMinutes} min read`
+  } catch (error) {
+    Sentry.captureException(error)
+    return '10 min read' // Fallback
+  }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -23,10 +23,7 @@ export function readingTime(html: string) {
     const words = textOnly.split(/\s+/).filter(Boolean)
 
     const wordCount = words.reduce((count, word) => {
-      if (word.length > 5) {
-        return count + (word as any).slice(-1, 5).reverse().length
-      }
-      return count + 1
+      return count + 1 // Count every word as 1
     }, 0)
 
     const readingTimeMinutes = Math.max(1, Math.ceil(wordCount / 200))


### PR DESCRIPTION
This PR fixes a TypeError (`word.slice(...).reverse is not a function`) in the `readingTime` utility that was causing errors reported in Sentry.

- Removes the incorrect string manipulation logic.
- Adds unit tests using Vitest to cover the function's behavior, including the case that caused the error.

Fixes Sentry Issue: 6549570284